### PR TITLE
Fix Comma in Enrichments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+Copyright (c) 2015-2016 Qntfy Corporation.
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # nifi-redis 
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Latest Release](https://img.shields.io/github/release/qntfy/nifi-redis.svg)](https://github.com/qntfy/nifi-redis/releases/latest)
+[![Software License](https://img.shields.io/github/license/qntfy/nifi-redis.svg)](LICENSE.md)
 [![Build Status](https://travis-ci.org/qntfy/nifi-redis.svg?branch=master)](https://travis-ci.org/qntfy/nifi-redis)
+[![Total Downloads](https://img.shields.io/github/downloads/qntfy/nifi-redis/total.svg)](https://github.com/qntfy/nifi-redis/releases)
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# nifi-redis [![Build Status](https://travis-ci.org/qntfy/nifi-redis.svg?branch=master)](https://travis-ci.org/qntfy/nifi-redis)
+NiFi Processors for handling data in Redis
+
+## Processors
+### GetRedis
+This processor is currently incomplete, but will be a simple Redis source, much like GetKafka. 
+New FlowFiles will be created from the contents of a Redis key(s).
+
+### GetRedisEnrichment
+This processor is under active development. 
+The processor accepts FlowFiles and then looks at the contents of a Redis hash based on the processor's configured "topic" and the UUID of the flowfile.
+If the specified number of values are in the redis hash for the given flowfile, the contents from Redis will either be added as attributes to the FlowFile or used to enrich the content. 
+Currently, only enrichment of JSON is supported.
+
+#### Configuration Options
+- **Redis Connection String**: The Connection String to use in order to connect to Redis.
+- **Client Name**: Client Name to use when communicating with Redis
+- **Topic**: Prefix of keys to gather data from, i.e. $topic:$flowfileUUID
+- **Enrichments**: Number of required enrichments in the key's hash
+- **JSON Content Mode**: If TRUE, add the enrichment data to the JSON, otherwise add as FlowFile attributes
+- **JSON Enrichment Field**: If in JSON Content Mode, add the enrichments to this top-level JSON field

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# nifi-redis [![Build Status](https://travis-ci.org/qntfy/nifi-redis.svg?branch=master)](https://travis-ci.org/qntfy/nifi-redis)
+# nifi-redis 
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Build Status](https://travis-ci.org/qntfy/nifi-redis.svg?branch=master)](https://travis-ci.org/qntfy/nifi-redis)
+
+
+
 NiFi Processors for handling data in Redis
 
 ## Processors

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.qntfy.nifi</groupId>
     <artifactId>nifi-redis</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.1.0</version>
     <packaging>nar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.qntfy.nifi</groupId>
     <artifactId>nifi-redis</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <packaging>nar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
 		    <artifactId>javax.json</artifactId>
 		    <version>1.0.4</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.4</version>
+		</dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.qntfy.nifi</groupId>
     <artifactId>nifi-redis</artifactId>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
     <packaging>nar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.qntfy.nifi</groupId>
     <artifactId>nifi-redis</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.1.2-SNAPSHOT</version>
     <packaging>nar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.qntfy.nifi</groupId>
     <artifactId>nifi-redis</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.1.2</version>
     <packaging>nar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.qntfy.nifi</groupId>
     <artifactId>nifi-redis</artifactId>
-    <version>0.1.4</version>
+    <version>0.1.5</version>
     <packaging>nar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.qntfy.nifi</groupId>
     <artifactId>nifi-redis</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1-SNAPSHOT</version>
     <packaging>nar</packaging>
 
     <properties>

--- a/src/main/java/io/qntfy/nifi/processors/GetRedisEnrichment.java
+++ b/src/main/java/io/qntfy/nifi/processors/GetRedisEnrichment.java
@@ -167,8 +167,10 @@ public class GetRedisEnrichment extends AbstractProcessor {
                 String uuid = flowFile.getAttribute("uuid");
                 String flowFileKey = source + ":" + uuid;
                 
-                // if not all the values exist
-                if (jedis.hlen(flowFileKey) != requiredEnrichments) {
+                if (requiredEnrichments == 0) {
+                    logger.info("Transferred {} to 'success'", new Object[] {flowFile});
+                    session.transfer(flowFile, REL_SUCCESS);
+                } else if (jedis.hlen(flowFileKey) != requiredEnrichments) {
                     String attemptsStr = flowFile.getAttribute(attemptsAttribute);
                     Integer attempts = (attemptsStr == null) ? 0 : Integer.valueOf(attemptsStr);
                     attempts += 1;

--- a/src/main/java/io/qntfy/nifi/processors/GetRedisEnrichment.java
+++ b/src/main/java/io/qntfy/nifi/processors/GetRedisEnrichment.java
@@ -169,6 +169,7 @@ public class GetRedisEnrichment extends AbstractProcessor {
                     
                     flowFile = session.putAttribute(flowFile, attemptsAttribute, String.valueOf(attempts));                 
                     flowFile = session.penalize(flowFile);
+                    logger.info("Transferred {} to 'retry', attempt {}", new Object[] {uuid, attempts});
                     session.getProvenanceReporter().modifyAttributes(flowFile, "FlowFile modified with attempt attribute");
                     session.transfer(flowFile, REL_RETRY);
                 } else {
@@ -180,6 +181,7 @@ public class GetRedisEnrichment extends AbstractProcessor {
                 }
             }
         } catch (JedisConnectionException e) { 
+            logger.error("Failed to connect to Redis due to {}; routing flowfiles to failure", new Object[] { e.getMessage() });
             session.transfer(flowFiles, REL_FAILURE);
         }
 	}

--- a/src/main/java/io/qntfy/nifi/util/JSONFlowFileEnricherImpl.java
+++ b/src/main/java/io/qntfy/nifi/util/JSONFlowFileEnricherImpl.java
@@ -23,7 +23,7 @@ public class JSONFlowFileEnricherImpl implements FlowFileEnricher {
         return ff;
     }
     
-    private static String makeJsonFromMapOfJsons(Map<String, String> content) {
+    protected static String makeJsonFromMapOfJsons(Map<String, String> content) {
         StringBuilder sb = new StringBuilder();
         sb.append("{");
         int i = 0;
@@ -32,7 +32,7 @@ public class JSONFlowFileEnricherImpl implements FlowFileEnricher {
                 sb.append(", ");
             }
             i += 1;
-            sb.append(e.getKey() + ": " + e.getValue());
+            sb.append("\"" + e.getKey() + "\": " + e.getValue());
         }
         sb.append("}");
         return sb.toString();

--- a/src/main/java/io/qntfy/nifi/util/StreamingJSONAppender.java
+++ b/src/main/java/io/qntfy/nifi/util/StreamingJSONAppender.java
@@ -15,6 +15,7 @@ import org.apache.nifi.processor.io.StreamCallback;
 public class StreamingJSONAppender implements StreamCallback {
     private final String field;
     private final String content;
+    private final boolean hasContent;
     private final Stack<String> depth = new Stack<>();
     private static final String A = "A";
     private static final String O = "O";
@@ -27,6 +28,12 @@ public class StreamingJSONAppender implements StreamCallback {
             throw new IllegalArgumentException("content must be valid JSON");
         }
         this.content = content.substring(start + 1, end);
+        if (this.content.replaceAll("\\s", "").length() == 0) {
+            this.hasContent = false;
+        } else {
+            this.hasContent = true;
+        }
+        
     }
     
     private static void writeComma(Event prev, OutputStream out) throws IOException {
@@ -89,7 +96,7 @@ public class StreamingJSONAppender implements StreamCallback {
                     str = "\"" + StringEscapeUtils.escapeJson(this.field) + "\": {" + this.content + "}";
                     out.write(str.getBytes());
                 }
-                if (insideTarget && depthPastTarget == 1) {
+                if (insideTarget && depthPastTarget == 1 && hasContent) {
                     writeComma(prev, out);
                     out.write(this.content.getBytes());
                     insideTarget = false;

--- a/src/main/java/io/qntfy/nifi/util/StreamingJSONAppender.java
+++ b/src/main/java/io/qntfy/nifi/util/StreamingJSONAppender.java
@@ -62,6 +62,9 @@ public class StreamingJSONAppender implements StreamCallback {
                 
                 break;
             case START_ARRAY:
+                if (prev == Event.END_ARRAY) {
+                    out.write(", ".getBytes());
+                }
                 out.write("[".getBytes());
                 depth.push(A);
                 break;

--- a/src/test/java/io/qntfy/nifi/util/JSONFlowFileEnricherImplTest.java
+++ b/src/test/java/io/qntfy/nifi/util/JSONFlowFileEnricherImplTest.java
@@ -17,4 +17,12 @@ public class JSONFlowFileEnricherImplTest {
         String expectedJson = "{\"jsonKey1\": {\"text\": \"json blob 1\"}, \"jsonKey2\": {\"text\": \"json blob 2\"}}";
         assertEquals("Combined json is malformed.", expectedJson, combinedJson);
     }
+    
+    @Test
+    public void makeJsonFromEmptyMapOfJsonsTest() {
+        Map<String, String> jsonMap = new TreeMap<>();
+        String combinedJson = JSONFlowFileEnricherImpl.makeJsonFromMapOfJsons(jsonMap);
+        String expectedJson = "{}";
+        assertEquals("Combined json is malformed.", expectedJson, combinedJson);
+    }
 }

--- a/src/test/java/io/qntfy/nifi/util/JSONFlowFileEnricherImplTest.java
+++ b/src/test/java/io/qntfy/nifi/util/JSONFlowFileEnricherImplTest.java
@@ -1,0 +1,20 @@
+package io.qntfy.nifi.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.Test;
+
+public class JSONFlowFileEnricherImplTest {
+    @Test
+    public void makeJsonFromMapOfJsonsTest() {
+        Map<String, String> jsonMap = new TreeMap<>();
+        jsonMap.put("jsonKey1", "{\"text\": \"json blob 1\"}");
+        jsonMap.put("jsonKey2", "{\"text\": \"json blob 2\"}");
+        String combinedJson = JSONFlowFileEnricherImpl.makeJsonFromMapOfJsons(jsonMap);
+        String expectedJson = "{\"jsonKey1\": {\"text\": \"json blob 1\"}, \"jsonKey2\": {\"text\": \"json blob 2\"}}";
+        assertEquals("Combined json is malformed.", expectedJson, combinedJson);
+    }
+}

--- a/src/test/java/io/qntfy/nifi/util/StreamingJSONAppenderTest.java
+++ b/src/test/java/io/qntfy/nifi/util/StreamingJSONAppenderTest.java
@@ -29,6 +29,21 @@ public class StreamingJSONAppenderTest {
     }
     
     @Test
+    public void testEmptyAppendToExistingEnrichmentField() throws IOException {
+        String data = "{}";
+        StreamingJSONAppender sja = new StreamingJSONAppender("enrichment", data);
+        
+        String input = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}, \"enrichment\": {\"existing\": \"value3\"}}";
+        String output = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}, \"enrichment\": {\"existing\": \"value3\"}}";
+        
+        InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
+        OutputStream os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        assertEquals("JSON string is malformed.", output, os.toString());
+    }
+    
+    @Test
     public void testMultipleEnrichments() throws IOException {
         String data = "{\"spinseeker\": {\"text\": \"spinseeker value\"}}";
         StreamingJSONAppender sja = new StreamingJSONAppender("metrics", data);
@@ -94,12 +109,42 @@ public class StreamingJSONAppenderTest {
     }
     
     @Test
+    public void testAppendToExistingEmptyEnrichmentFieldEmpty() throws IOException {
+        String data = "{}";
+        StreamingJSONAppender sja = new StreamingJSONAppender("enrichment", data);
+        
+        String input = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}, \"enrichment\": {}}";
+        String output = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}, \"enrichment\": {}}";
+        
+        InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
+        OutputStream os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        assertEquals("JSON string is malformed.", output, os.toString());
+    }
+    
+    @Test
     public void testAddNewEnrichmentField() throws IOException {
         String data = "{\"test\": \"value\"}";
         StreamingJSONAppender sja = new StreamingJSONAppender("enrichment", data);
         
         String input = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}}";
         String output = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}, \"enrichment\": {\"test\": \"value\"}}";
+        
+        InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
+        OutputStream os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        assertEquals("JSON string is malformed.", output, os.toString());
+    }
+    
+    @Test
+    public void testAddNewEnrichmentFieldEmpty() throws IOException {
+        String data = "{}";
+        StreamingJSONAppender sja = new StreamingJSONAppender("enrichment", data);
+        
+        String input = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}}";
+        String output = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}, \"enrichment\": {}}";
         
         InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
         OutputStream os = new ByteArrayOutputStream();

--- a/src/test/java/io/qntfy/nifi/util/StreamingJSONAppenderTest.java
+++ b/src/test/java/io/qntfy/nifi/util/StreamingJSONAppenderTest.java
@@ -27,7 +27,57 @@ public class StreamingJSONAppenderTest {
         
         assertEquals("JSON string is malformed.", output, os.toString());
     }
+    
+    @Test
+    public void testMultipleEnrichments() throws IOException {
+        String data = "{\"spinseeker\": {\"text\": \"spinseeker value\"}}";
+        StreamingJSONAppender sja = new StreamingJSONAppender("metrics", data);
+        
+        String input = "{\"uuid\": \"abcd1234\", \"original\": {\"text\": \"original tweet\"}}";
+        String output = "{\"uuid\": \"abcd1234\", \"original\": {\"text\": \"original tweet\"}, \"metrics\": {\"spinseeker\": {\"text\": \"spinseeker value\"}}}";
+        
+        InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
+        OutputStream os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        assertEquals("JSON string is malformed after first enrichment.", output, os.toString());
 
+        data = "{\"english_text\": {\"text\": \"translated value\"}}";
+        sja = new StreamingJSONAppender("metrics", data);
+        
+        is = new ByteArrayInputStream(os.toString().getBytes(Charset.defaultCharset()));
+        os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        output = "{\"uuid\": \"abcd1234\", \"original\": {\"text\": \"original tweet\"}, \"metrics\": {\"spinseeker\": {\"text\": \"spinseeker value\"}, \"english_text\": {\"text\": \"translated value\"}}}";
+        assertEquals("JSON string is malformed after second enrichment.", output, os.toString());
+    }
+
+    @Test
+    public void testMultipleEnrichmentsWithAdvancedObjects() throws IOException {
+        String data = "{\"spinseeker\": {\"text\": \"spinseeker value\", \"data\": {\"score\": 12, \"ver\": \"beta\"}}}";
+        StreamingJSONAppender sja = new StreamingJSONAppender("metrics", data);
+        
+        String input = "{\"uuid\": \"abcd1234\", \"original\": {\"text\": \"original tweet\", \"user\": {\"name\": \"ryan\", \"id_str\": \"12345\"}}}";
+        String output = "{\"uuid\": \"abcd1234\", \"original\": {\"text\": \"original tweet\", \"user\": {\"name\": \"ryan\", \"id_str\": \"12345\"}}, \"metrics\": {\"spinseeker\": {\"text\": \"spinseeker value\", \"data\": {\"score\": 12, \"ver\": \"beta\"}}}}";
+                
+        InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
+        OutputStream os = new ByteArrayOutputStream();
+        sja.process(is, os);
+                
+        assertEquals("JSON string is malformed after first enrichment.", output, os.toString());
+
+        data = "{\"english_text\": {\"text\": \"translated value\", \"abc\": {\"key\": \"value\"}}}";
+        sja = new StreamingJSONAppender("metrics", data);
+        
+        is = new ByteArrayInputStream(os.toString().getBytes(Charset.defaultCharset()));
+        os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        output = "{\"uuid\": \"abcd1234\", \"original\": {\"text\": \"original tweet\", \"user\": {\"name\": \"ryan\", \"id_str\": \"12345\"}}, \"metrics\": {\"spinseeker\": {\"text\": \"spinseeker value\", \"data\": {\"score\": 12, \"ver\": \"beta\"}}, \"english_text\": {\"text\": \"translated value\", \"abc\": {\"key\": \"value\"}}}}";
+        assertEquals("JSON string is malformed after second enrichment.", output, os.toString());
+    }
+    
     @Test
     public void testAppendToExistingEmptyEnrichmentField() throws IOException {
         String data = "{\"test\": \"value\"}";

--- a/src/test/java/io/qntfy/nifi/util/StreamingJSONAppenderTest.java
+++ b/src/test/java/io/qntfy/nifi/util/StreamingJSONAppenderTest.java
@@ -57,4 +57,50 @@ public class StreamingJSONAppenderTest {
         
         assertEquals("JSON string is malformed.", output, os.toString());
     }
+    
+    
+    @Test
+    public void testEscapedJson() throws IOException {
+        String data = "{\"test\": \"value\"}";
+        StreamingJSONAppender sja = new StreamingJSONAppender("enrichment", data);
+        
+        String input =  "{\"test\": {\"test2\": \"ABC\", \"test1\": \"<a href=\\\"http:\\/\\/test-url.com\\\"\\/>\"}}";
+        String output = "{\"test\": {\"test2\": \"ABC\", \"test1\": \"<a href=\\\"http:\\/\\/test-url.com\\\"\\/>\"}, \"enrichment\": {\"test\": \"value\"}}";
+        
+        InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
+        OutputStream os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        assertEquals("JSON string is malformed.", output, os.toString());
+    }
+    
+    @Test
+    public void testEscapedJsonWithBoolean() throws IOException {
+        String data = "{\"test\": \"value\"}";
+        StreamingJSONAppender sja = new StreamingJSONAppender("enrichment", data);
+        
+        String input =  "{\"test\": {\"test2\": true, \"test1\": \"<a href=\\\"http:\\/\\/test-url.com\\\"\\/>\"}}";
+        String output = "{\"test\": {\"test2\": true, \"test1\": \"<a href=\\\"http:\\/\\/test-url.com\\\"\\/>\"}, \"enrichment\": {\"test\": \"value\"}}";
+        
+        InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
+        OutputStream os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        assertEquals("JSON string is malformed.", output, os.toString());
+    }
+    
+    @Test
+    public void testArraysOfJsons() throws IOException {
+        String data = "{\"test\": \"value\"}";
+        StreamingJSONAppender sja = new StreamingJSONAppender("enrichment", data);
+        
+        String input =  "{\"test\": {\"test2\": [{\"a\": \"b\"}, {\"c\": \"d\"}], \"test1\": \"<a href=\\\"http:\\/\\/test-url.com\\\"\\/>\"}}";
+        String output = "{\"test\": {\"test2\": [{\"a\": \"b\"}, {\"c\": \"d\"}], \"test1\": \"<a href=\\\"http:\\/\\/test-url.com\\\"\\/>\"}, \"enrichment\": {\"test\": \"value\"}}";
+        
+        InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
+        OutputStream os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        assertEquals("JSON string is malformed.", output, os.toString());
+    }
 }

--- a/src/test/java/io/qntfy/nifi/util/StreamingJSONAppenderTest.java
+++ b/src/test/java/io/qntfy/nifi/util/StreamingJSONAppenderTest.java
@@ -103,4 +103,21 @@ public class StreamingJSONAppenderTest {
         
         assertEquals("JSON string is malformed.", output, os.toString());
     }
+    
+    @Test
+    public void testNestedArrays() throws IOException {
+        String data = "{\"test\": \"value\"}";
+        StreamingJSONAppender sja = new StreamingJSONAppender("enrichment", data);
+        
+        String input =  "{\"test\": {\"coordinates\": [[[-12, 23], [-72.18, 14.23]]], \"type\": \"Polygon\"}}";
+        String output = "{\"test\": {\"coordinates\": [[[-12, 23], [-72.18, 14.23]]], \"type\": \"Polygon\"}, \"enrichment\": {\"test\": \"value\"}}";
+        
+        InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
+        OutputStream os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        assertEquals("JSON string is malformed.", output, os.toString());
+    }
+    
+    
 }


### PR DESCRIPTION
Fix spurious comma in enrichment field when the `enrichement` field already exists, but there are no enrichments to add. Also adds a short-circuit so that the enrichment process is skipped entirely if no enrichments are expected.